### PR TITLE
Changes to stdout table styling

### DIFF
--- a/internal/commands/aws-presets/presets.go
+++ b/internal/commands/aws-presets/presets.go
@@ -26,7 +26,6 @@ func runCommand(cmd *cobra.Command, args []string) {
 	optionsNameList := PromptQueryList(presets)
 
 	var prompt = Prompt(optionsNameList)
-
 	selection := 0
 	err := survey.AskOne(prompt, &selection)
 	if err != nil {
@@ -45,7 +44,6 @@ func runCommand(cmd *cobra.Command, args []string) {
 	}
 
 	DisplaySynthesizedQuery(selectedOption)
-
 	err = execute(apiRequest)
 	if err != nil {
 		fmt.Println(err.Error())
@@ -64,9 +62,6 @@ func Prompt(o []string) *survey.Select {
 	return &survey.Select{
 		Message: "Choose a query to execute:",
 		Options: o,
-		//Description: func(value string, index int) string {
-		//	return strings.Join(presets[index].Description, ",")
-		//},
 	}
 }
 
@@ -100,7 +95,6 @@ func DisplaySynthesizedQuery(p PresetParams) {
 }
 
 func execute(q aws.CostAndUsageRequestType) error {
-
 	err := aws3.ExecutePreset(q)
 	if err != nil {
 		err := PresetError{
@@ -108,6 +102,5 @@ func execute(q aws.CostAndUsageRequestType) error {
 		}
 		return err
 	}
-
 	return nil
 }

--- a/pkg/printer/forecast.go
+++ b/pkg/printer/forecast.go
@@ -9,22 +9,10 @@ func ForecastToStdout(r ForecastPrintData,
 	dimensions []string) {
 
 	filteredBy := strings.Join(dimensions, " | ")
-
 	output := ConvertToForecastStdoutType(r, filteredBy)
-
 	w, err := stdout.NewStdoutWriter("forecast")
 	if err != nil {
 		return
 	}
 	w.Writer(output)
-	//t := CreateTable(forecastedHeader)
-	//rows := ForecastToRows(r)
-	//t.AppendRows(rows)
-
-	//footer := forecastedTableFooter(filteredBy, *r.Forecast.Total.Unit, *r.Forecast.Total.Amount)
-	//t.AppendRow(footer)
-	//t.Render()
-	//
-	//stdout.Writer(output, "forecast")
-
 }

--- a/pkg/printer/forecast.go
+++ b/pkg/printer/forecast.go
@@ -1,32 +1,30 @@
 package printer
 
 import (
-	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/cduggn/ccexplorer/pkg/printer/writers/stdout"
 	"strings"
-)
-
-var (
-	forecastedHeader = table.Row{"Start", "End", "Mean Value",
-		"Prediction Interval LowerBound",
-		"Prediction Interval UpperBound", "Unit", "Total"}
-	forecastedTableFooter = func(filter string, unit string,
-		amount string) table.Row {
-		return table.Row{"FilteredBy", filter, "", "", "",
-			unit,
-			amount}
-	}
 )
 
 func ForecastToStdout(r ForecastPrintData,
 	dimensions []string) {
+
 	filteredBy := strings.Join(dimensions, " | ")
 
-	t := CreateTable(forecastedHeader)
-	rows := ForecastToRows(r)
-	t.AppendRows(rows)
+	output := ConvertToForecastStdoutType(r, filteredBy)
 
-	footer := forecastedTableFooter(filteredBy, *r.Forecast.Total.Unit,
-		*r.Forecast.Total.Amount)
-	t.AppendRow(footer)
-	t.Render()
+	w, err := stdout.NewStdoutWriter("forecast")
+	if err != nil {
+		return
+	}
+	w.Writer(output)
+	//t := CreateTable(forecastedHeader)
+	//rows := ForecastToRows(r)
+	//t.AppendRows(rows)
+
+	//footer := forecastedTableFooter(filteredBy, *r.Forecast.Total.Unit, *r.Forecast.Total.Amount)
+	//t.AppendRow(footer)
+	//t.Render()
+	//
+	//stdout.Writer(output, "forecast")
+
 }

--- a/pkg/printer/handler.go
+++ b/pkg/printer/handler.go
@@ -39,7 +39,10 @@ func (p *StdoutPrinter) Print(f interface{}, c interface{}) error {
 		ForecastToStdout(f.(ForecastPrintData), c.([]string))
 	case "costAndUsage":
 		fn := SortFunction(f.(string))
-		CostAndUsageToStdout(fn, c.(CostAndUsageOutputType))
+		err := CostAndUsageToStdout(fn, c.(CostAndUsageOutputType))
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 

--- a/pkg/printer/types.go
+++ b/pkg/printer/types.go
@@ -2,7 +2,6 @@ package printer
 
 import (
 	"github.com/aws/aws-sdk-go-v2/service/costexplorer"
-	"github.com/jedib0t/go-pretty/v6/table"
 )
 
 type PrintWriterType int
@@ -46,11 +45,6 @@ type OpenAIPrinter struct {
 
 type ChartPrinter struct {
 	Variant string
-}
-
-type CostAndUsage struct {
-	Rows  []table.Row
-	Total string
 }
 
 type CostAndUsageReport struct {

--- a/pkg/printer/types.go
+++ b/pkg/printer/types.go
@@ -9,11 +9,6 @@ type PrintWriterType int
 type SortBy int
 
 const (
-	Amount SortBy = iota
-	Date
-)
-
-const (
 	Stdout PrintWriterType = iota
 	CSV
 	Chart

--- a/pkg/printer/writers/stdout/stdout_writer.go
+++ b/pkg/printer/writers/stdout/stdout_writer.go
@@ -1,0 +1,150 @@
+package stdout
+
+import (
+	"fmt"
+	"github.com/jedib0t/go-pretty/v6/table"
+	"os"
+)
+
+var (
+	tableDivider = table.Row{"-", "-", "-",
+		"-", "-", "-", "-",
+		"-",
+		"-", ""}
+	costAndUsageHeader = table.Row{"Rank", "Dimension/Tag", "Dimension/Tag",
+		"Metric Name", "Truncated USD Amount", "Amount",
+		"Unit",
+		"Granularity",
+		"Start",
+		"End"}
+	costAndUsageTableFooter = func(t string) table.Row {
+		return table.
+		Row{"", "",
+			"",
+			"",
+			"TOTAL COST",
+			t, "", "", "", ""}
+	}
+	forecastedHeader = table.Row{"Start", "End", "Mean Value",
+		"Prediction Interval LowerBound",
+		"Prediction Interval UpperBound", "Unit", "Total"}
+	forecastedTableFooter = func(filter string, unit string,
+		amount string) table.Row {
+		return table.Row{"FilteredBy", filter, "", "", "",
+			unit,
+			amount}
+	}
+)
+
+func NewStdoutWriter(variant string) (Table, error) {
+	switch variant {
+	case "forecast":
+		return ForecastTable{
+			Table: table.NewWriter(),
+		}, nil
+	case "costAndUsage":
+		return CostAndUsageTable{
+			Table: table.NewWriter(),
+		}, nil
+	}
+
+	return nil, fmt.Errorf("unknown table type: %s", variant)
+}
+
+func (c CostAndUsageTable) Writer(output interface{}) {
+	outputType := output.(CostAndUsageStdoutType)
+	c.Table.SetOutputMirror(os.Stdout)
+	c.Header()
+	rows := CostUsageToRows(outputType.Services, outputType.Granularity)
+
+	c.AddRows(rows.Rows)
+	c.Table.AppendRow(tableDivider)
+	c.Footer(costAndUsageTableFooter(rows.Total))
+	c.Table.Render()
+}
+
+func (f ForecastTable) Writer(output interface{}) {
+	outputType := output.(ForecastStdoutType)
+	f.Table.SetOutputMirror(os.Stdout)
+	f.Header()
+	rows := ForecastToRows(outputType)
+	f.AddRows(rows)
+
+	f.Footer(forecastedTableFooter(outputType.FilteredBy,
+		outputType.Total.Unit, outputType.Total.Amount))
+
+	f.Table.Render()
+}
+
+func (c CostAndUsageTable) Header() {
+	c.Table.AppendHeader(costAndUsageHeader)
+}
+
+func (c CostAndUsageTable) AddRows(rows []table.Row) {
+	c.Table.AppendRows(rows)
+}
+
+func (c CostAndUsageTable) Footer(row table.Row) {
+	c.Table.AppendFooter(row)
+}
+
+func (f ForecastTable) Footer(row table.Row) {
+	f.Table.AppendFooter(row)
+}
+
+func (f ForecastTable) AddRows(rows []table.Row) {
+	f.Table.AppendRows(rows)
+}
+
+func (f ForecastTable) Header() {
+	//t.SetOutputMirror(os.Stdout)
+	f.Table.AppendHeader(forecastedHeader)
+}
+
+func CostUsageToRows(s []Service, granularity string) CostAndUsage {
+	var rows []table.Row
+	var total float64
+	for index, v := range s {
+		for _, m := range v.Metrics {
+
+			if index%10 == 0 {
+				rows = append(rows, tableDivider)
+			}
+			if m.Unit == "USD" {
+				total += m.NumericAmount
+			}
+
+			tempRow := table.Row{index, v.Keys[0], ReturnIfPresent(v.Keys),
+				m.Name, fmt.Sprintf("%f10",
+					m.NumericAmount), m.Amount,
+				m.Unit,
+				granularity,
+				v.Start, v.End}
+
+			rows = append(rows, tempRow)
+		}
+	}
+	totalFormatted := fmt.Sprintf("%f10", total)
+	return CostAndUsage{Rows: rows, Total: totalFormatted}
+}
+
+func ForecastToRows(r ForecastStdoutType) []table.Row {
+	var rows []table.Row
+	for _, v := range r.Forecast {
+		tempRow := table.Row{v.TimePeriod.Start,
+			v.TimePeriod.End, v.MeanValue, v.PredictionIntervalUpperBound,
+			v.PredictionIntervalLowerBound}
+
+		rows = append(rows, tempRow)
+	}
+	return rows
+}
+
+func ReturnIfPresent(s []string) string {
+	if len(s) == 1 {
+		return ""
+	} else {
+		return s[1]
+	}
+
+}

--- a/pkg/printer/writers/stdout/stdout_writer.go
+++ b/pkg/printer/writers/stdout/stdout_writer.go
@@ -19,7 +19,7 @@ var (
 		"End"}
 	costAndUsageTableFooter = func(t string) table.Row {
 		return table.
-		Row{"", "",
+			Row{"", "",
 			"",
 			"",
 			"TOTAL COST",
@@ -54,6 +54,7 @@ func NewStdoutWriter(variant string) (Table, error) {
 func (c CostAndUsageTable) Writer(output interface{}) {
 	outputType := output.(CostAndUsageStdoutType)
 	c.Table.SetOutputMirror(os.Stdout)
+	c.Table.SetStyle(table.StyleColoredCyanWhiteOnBlack)
 	c.Header()
 	rows := CostUsageToRows(outputType.Services, outputType.Granularity)
 

--- a/pkg/printer/writers/stdout/stdout_writer.go
+++ b/pkg/printer/writers/stdout/stdout_writer.go
@@ -7,10 +7,10 @@ import (
 )
 
 var (
-	tableDivider = table.Row{"-", "-", "-",
-		"-", "-", "-", "-",
-		"-",
-		"-", ""}
+	tableDivider = table.Row{"", "", "",
+		"", "", "", "",
+		"",
+		"", ""}
 	costAndUsageHeader = table.Row{"Rank", "Dimension/Tag", "Dimension/Tag",
 		"Metric Name", "Truncated USD Amount", "Amount",
 		"Unit",
@@ -55,6 +55,7 @@ func (c CostAndUsageTable) Writer(output interface{}) {
 	outputType := output.(CostAndUsageStdoutType)
 	c.Table.SetOutputMirror(os.Stdout)
 	c.Table.SetStyle(table.StyleColoredCyanWhiteOnBlack)
+	c.Table.SuppressEmptyColumns()
 	c.Header()
 	rows := CostUsageToRows(outputType.Services, outputType.Granularity)
 
@@ -67,6 +68,9 @@ func (c CostAndUsageTable) Writer(output interface{}) {
 func (f ForecastTable) Writer(output interface{}) {
 	outputType := output.(ForecastStdoutType)
 	f.Table.SetOutputMirror(os.Stdout)
+	f.Table.SetOutputMirror(os.Stdout)
+	f.Table.SetStyle(table.StyleColoredCyanWhiteOnBlack)
+	//f.Table.SuppressEmptyColumns()
 	f.Header()
 	rows := ForecastToRows(outputType)
 	f.AddRows(rows)

--- a/pkg/printer/writers/stdout/types.go
+++ b/pkg/printer/writers/stdout/types.go
@@ -9,6 +9,7 @@ type Table interface {
 	Header()
 	Footer(row table.Row)
 	AddRows(rows []table.Row)
+	Style()
 }
 
 type CostAndUsageTable struct {

--- a/pkg/printer/writers/stdout/types.go
+++ b/pkg/printer/writers/stdout/types.go
@@ -1,0 +1,69 @@
+package stdout
+
+import (
+	"github.com/jedib0t/go-pretty/v6/table"
+)
+
+type Table interface {
+	Writer(interface{})
+	Header()
+	Footer(row table.Row)
+	AddRows(rows []table.Row)
+}
+
+type CostAndUsageTable struct {
+	Table table.Writer
+}
+
+type ForecastTable struct {
+	Table table.Writer
+}
+
+type CostAndUsage struct {
+	Rows  []table.Row
+	Total string
+}
+
+type CostAndUsageStdoutType struct {
+	Granularity string
+	Services    []Service
+}
+
+type Service struct {
+	Keys    []string
+	Name    string
+	Metrics []Metrics
+	Start   string
+	End     string
+}
+
+type Metrics struct {
+	Name          string
+	Amount        string
+	NumericAmount float64
+	Unit          string
+	UsageQuantity float64
+}
+
+type ForecastStdoutType struct {
+	Forecast   []ForecastResults
+	FilteredBy string
+	Total      Total
+}
+
+type Total struct {
+	Amount string
+	Unit   string
+}
+
+type ForecastResults struct {
+	MeanValue                    string
+	PredictionIntervalLowerBound string
+	PredictionIntervalUpperBound string
+	TimePeriod                   DateInterval
+}
+
+type DateInterval struct {
+	End   string
+	Start string
+}


### PR DESCRIPTION
- Refactor stdout logic, add stdout package and use interface types to abstract underlying behaviors for costAndUsage and forecast request types
- Round the cost dollar amount to a precision of two decimal places
- Use go-pretty to hide columns with no values
- Use go-pretty style templates for table header, footer and rows
- Rename Truncated Amount USD column to Rounded for brevity
- Rename Total Cost in footer to Cost to reflect the fluid nature of cost and usage data