### PR TITLE
service: update the charge types excluded when using the -l flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ $ go run .\cmd\ccexplorer\ccexplorer.go get aws -g DIMENSION=SERVICE,DIMENSION=O
 
 ```console
 # download
-$ docker pull ghcr.io/cduggn/ccexplorer:v0.6.5
+$ docker pull ghcr.io/cduggn/ccexplorer:v0.7.0
 
 # Container requires AWS Access key, secret, and region
 $ docker run -it \
@@ -77,7 +77,7 @@ $ docker run -it \
   -e AWS_SECRET_ACCESS_KEY=<AWS_SECRET_ACCESS_KEY> \
   -e AWS_REGION=<AWS-REGION> \
   --mount type=bind,source="$(pwd)"/output/,target=/app/output \ 
-  ghcr.io/cduggn/ccexplorer:v0.6.5 get aws -g DIMENSION=OPERATION,DIMENSION=SERVICE \
+  ghcr.io/cduggn/ccexplorer:v0.7.0 get aws -g DIMENSION=OPERATION,DIMENSION=SERVICE \
   -l -p chart
   
 ```
@@ -266,7 +266,7 @@ flags
 - Results are sorted by default by cost in descending order. The `-d` flag 
   can be used to specify date sorting in descending order.
 - Refunds, discounts and credits are applied automatically. The `-l` flag 
-  should be used to exclude this behavior.
+  should be used to exclude this behavior. The full list of excluded charge types is: [Credit, Refund, Discount, BundledDiscount, SavingsPlanCoveredUsage, SavingsPlanNegation]
 - When filtering by cost allocation tags (`-f TAG="my-tag"`) a tag must also 
   be specified in the group by flag (`-g TAG=ApplicationName`). This 
   instructs the `ccExplorer` to filter by `ApplicationName=my-tag` .

--- a/internal/core/handlers/commandline/get.go
+++ b/internal/core/handlers/commandline/get.go
@@ -118,8 +118,7 @@ func (c *CostCommandType) DefineFlags() {
 
 	c.Cmd.Flags().BoolVarP(&costUsageWithoutDiscounts, "excludeDiscounts", "l",
 		false,
-		"Exclude credit, refunds, "+
-			"and discounts (default is to include)")
+		"Excludes the following charge categories: Credit, Refund, Discount, BundledDiscount, DiscountedUsage, SavingsPlanCoveredUsage, SavingsPlanNegation . ( Exclusions not enabled by default)")
 
 	c.Cmd.Flags().BoolVarP(&costUsageSortByDate, "sortByDate", "d",
 		false,

--- a/internal/core/service/aws/request_builder_utils.go
+++ b/internal/core/service/aws/request_builder_utils.go
@@ -52,7 +52,7 @@ var (
 			Not: &types.Expression{
 				Dimensions: &types.DimensionValues{
 					Key:    "RECORD_TYPE",
-					Values: []string{"Refund", "Credit", "DiscountedUsage", "BundledDiscount ", "SavingsPlanCoveredUsage", "SavingsPlanNegation"},
+					Values: []string{"Refund", "Credit", "DiscountedUsage", "Discount", "BundledDiscount ", "SavingsPlanCoveredUsage", "SavingsPlanNegation"},
 				},
 			},
 		}

--- a/internal/core/service/aws/request_builder_utils.go
+++ b/internal/core/service/aws/request_builder_utils.go
@@ -52,7 +52,7 @@ var (
 			Not: &types.Expression{
 				Dimensions: &types.DimensionValues{
 					Key:    "RECORD_TYPE",
-					Values: []string{"Refund", "Credit", "DiscountedUsage"},
+					Values: []string{"Refund", "Credit", "DiscountedUsage", "BundledDiscount ", "SavingsPlanCoveredUsage", "SavingsPlanNegation"},
 				},
 			},
 		}


### PR DESCRIPTION
### What
- PR adds additional charge types which will be filtered when the `-l` flag is used to exclude any discounts applied to the account. The new charge types are `discount`, `BundledDiscount`, `SavingsPlanCoveredUsage`, and `SavingsPlanNegation`
- Update release version

### PR Checklist

- [x] Read the [Contributing documentation](https://github.com/cduggn/ccExplorer/blob/main/CONTRIBUTING.md).
- [x] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [x] Describes the source of new concepts.
- [x] References existing implementations as appropriate.
- [x] Contains test coverage for new functions.
- [x] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.