### PR TITLE
feat: implement stdio-only MCP server for VSCode integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,32 @@ flags
   2022-10-10T00:00:00Z -e 2022-10-10T23:59:59Z`. 
   
 
+## MCP Server Integration
+
+`ccExplorer` includes a built-in MCP (Model Context Protocol) server that enables AI-powered cost analysis through VSCode and GitHub Copilot Chat integration.
+
+### Quick Setup
+
+1. **Enable MCP in VSCode**: Add `"chat.mcp.enabled": true` to your VSCode settings
+2. **Build ccExplorer**: Run `make build` to ensure the binary is available
+3. **Use with Copilot**: Open VSCode Copilot Chat in Agent Mode and start querying your AWS costs
+
+The repository includes a pre-configured `.vscode/mcp.json` file for automatic setup.
+
+### Example Queries
+
+```
+@agent What were my AWS costs for the last 30 days grouped by service?
+@agent Show my EC2 costs for the last quarter, excluding discounts
+@agent Compare my AWS costs between last month and this month
+```
+
+### Available Commands
+
+- `ccexplorer mcp serve` - Start MCP server with stdio transport (for VSCode integration)
+
+For detailed setup instructions, see [VSCode MCP Integration Guide](./docs/vscode-mcp-integration.md).
+
 ## Additional Information
 <hr>
 

--- a/cmd/cli/mcp_command.go
+++ b/cmd/cli/mcp_command.go
@@ -1,0 +1,70 @@
+package cli
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/cduggn/ccexplorer/internal/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/spf13/cobra"
+)
+
+// mcpCommand creates the MCP command structure
+func mcpCommand() *cobra.Command {
+	mcpCmd := &cobra.Command{
+		Use:   "mcp",
+		Short: "Model Context Protocol server for ccExplorer",
+		Long: `Start a Model Context Protocol (MCP) server that exposes ccExplorer functionality
+to AI systems through a standardized stdio interface.
+
+The MCP server provides:
+- get_cost_and_usage tool for AWS Cost Explorer queries
+- Stdio transport for VSCode and other MCP clients`,
+	}
+
+	// Add serve subcommand
+	serveCmd := &cobra.Command{
+		Use:   "serve",
+		Short: "Start the MCP server with stdio transport",
+		Long: `Start the Model Context Protocol server with stdio transport.
+
+This is the recommended transport mode for MCP clients like VSCode.
+
+Examples:
+  # Start MCP server for stdio transport (VSCode integration)
+  ccexplorer mcp serve
+
+The server will run until the MCP client disconnects or the process is terminated.`,
+		RunE: runMCPServe,
+	}
+
+	mcpCmd.AddCommand(serveCmd)
+	return mcpCmd
+}
+
+// runMCPServe handles the MCP serve command
+func runMCPServe(cmd *cobra.Command, args []string) error {
+	slog.Info("Starting ccExplorer MCP server with stdio transport")
+
+	// Configure AWS service (reuse existing service initialization)
+	if srv == nil {
+		Initialize()
+	}
+
+	// Create MCP server
+	mcpServer := mcp.NewServer(srv.aws)
+
+	// Register tools
+	if err := mcpServer.RegisterTools(); err != nil {
+		return fmt.Errorf("failed to register MCP tools: %w", err)
+	}
+
+	slog.Info("MCP tools registered successfully, starting stdio server")
+
+	// Start MCP server with stdio transport (recommended for MCP clients)
+	if err := server.ServeStdio(mcpServer.MCPServer()); err != nil {
+		return fmt.Errorf("MCP stdio server error: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/cli/root_command.go
+++ b/cmd/cli/root_command.go
@@ -24,6 +24,7 @@ func RootCommand() *cobra.Command {
 
 func init() {
 	rootCmd.AddCommand(CostAndForecast())
+	rootCmd.AddCommand(mcpCommand())
 	_ = viper.BindPFlag("openai_api_key", rootCmd.PersistentFlags().Lookup(
 		"OPENAI_API_KEY"))
 	_ = viper.BindPFlag("aws_profile", rootCmd.PersistentFlags().Lookup(

--- a/docs/vscode-mcp-integration.md
+++ b/docs/vscode-mcp-integration.md
@@ -1,0 +1,202 @@
+# VSCode + GitHub Copilot Integration with ccExplorer MCP Server
+
+This guide explains how to integrate ccExplorer's built-in MCP (Model Context Protocol) server with VSCode and GitHub Copilot Chat for AI-powered AWS cost analysis.
+
+## Prerequisites
+
+- VSCode 1.99 or later
+- GitHub Copilot extension enabled
+- ccExplorer binary built (`make build`)
+- AWS credentials configured (AWS CLI, environment variables, or IAM roles)
+
+## Quick Setup
+
+### 1. Enable MCP in VSCode
+
+Add this setting to your VSCode configuration:
+
+```json
+{
+  "chat.mcp.enabled": true
+}
+```
+
+### 2. Workspace Configuration (Recommended)
+
+The repository includes a pre-configured `.vscode/mcp.json` file that will automatically connect ccExplorer's MCP server to VSCode Copilot Chat.
+
+When you first use the MCP server, VSCode will prompt you for:
+- **AWS Access Key ID** (optional - leave empty to use default credential chain)
+- **AWS Secret Access Key** (optional - leave empty to use default credential chain) 
+- **AWS Region** (e.g., `us-east-1`, `us-west-2`)
+
+### 3. Build ccExplorer
+
+Ensure the binary is available:
+
+```bash
+make build
+```
+
+## Alternative Setup Methods
+
+### User Settings (Global Configuration)
+
+To enable ccExplorer MCP across all workspaces, add this to your VSCode user settings:
+
+```json
+{
+  "chat.mcp.enabled": true,
+  "chat.mcp.servers": {
+    "ccExplorer": {
+      "type": "stdio",
+      "command": "/path/to/your/ccexplorer",
+      "args": ["mcp", "serve"],
+      "env": {
+        "AWS_REGION": "us-east-1"
+      }
+    }
+  }
+}
+```
+
+## Usage with GitHub Copilot Chat
+
+### 1. Open Copilot Chat in Agent Mode
+
+1. Open the Chat view (`Ctrl+Shift+P` → "Chat: Open")
+2. Select **Agent Mode** from the dropdown
+3. Click the **Tools** button and ensure ccExplorer tools are enabled
+
+### 2. Example Queries
+
+Here are practical examples of how to use ccExplorer through Copilot Chat:
+
+#### Basic Cost Analysis
+```
+@agent What were my AWS costs for the last 30 days grouped by service?
+```
+
+#### Monthly Cost Trends
+```
+@agent Show my AWS costs for the last 6 months with monthly granularity, grouped by service
+```
+
+#### Service-Specific Analysis
+```
+@agent What are my EC2 costs for the last quarter, excluding discounts?
+```
+
+#### Tag-Based Cost Analysis
+```
+@agent Show costs grouped by ProjectName tag for the last month
+```
+
+#### Cost Comparison
+```
+@agent Compare my AWS costs between last month and this month
+```
+
+### 3. Available MCP Tools
+
+The ccExplorer MCP server provides the following tool:
+
+#### `get_cost_and_usage`
+
+**Parameters:**
+- `start_date` (required): Start date in YYYY-MM-DD format
+- `end_date` (required): End date in YYYY-MM-DD format  
+- `granularity` (optional): DAILY, MONTHLY, or HOURLY
+- `metrics` (optional): Cost metrics to retrieve (UnblendedCost, AmortizedCost, etc.)
+- `group_by` (optional): Group results by SERVICE, AZ, INSTANCE_TYPE, or TAG:TagName
+- `filter_by_service` (optional): Filter to specific AWS services
+- `exclude_discounts` (optional): Exclude discount information
+
+## Troubleshooting
+
+### Check MCP Server Status
+
+Use VSCode's Command Palette:
+```
+MCP: List Servers
+```
+
+This shows configured servers and their status, with options to start/stop/restart and view logs.
+
+### Common Issues
+
+1. **Server Not Starting**
+   - Ensure `./ccexplorer` binary exists and is executable
+   - Check AWS credentials are configured correctly
+   - Verify AWS region is set
+
+2. **Permission Denied**
+   - Make sure ccExplorer binary has execute permissions: `chmod +x ./ccexplorer`
+
+3. **AWS Authentication Errors**
+   - Verify AWS credentials with: `aws sts get-caller-identity`
+   - Check that your AWS credentials have Cost Explorer permissions
+
+4. **Tool Not Available in Chat**
+   - Ensure you're in Agent Mode
+   - Check that ccExplorer tools are enabled in the Tools panel
+   - Restart the MCP server if needed
+
+### Debug Mode
+
+For detailed logging, you can run the MCP server manually with environment variables:
+
+```bash
+# Enable debug logging
+CCEXPLORER_LOG_LEVEL=debug ./ccexplorer mcp serve
+```
+
+### Test MCP Server
+
+You can test the MCP server directly using stdio:
+
+```bash
+# Test tools list
+echo '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | ./ccexplorer mcp serve
+
+# Test tool call (requires AWS credentials)
+echo '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_cost_and_usage","arguments":{"start_date":"2024-01-01","end_date":"2024-01-31"}}}' | ./ccexplorer mcp serve
+```
+
+## Security Considerations
+
+- The MCP server runs locally and connects directly to AWS APIs
+- AWS credentials are handled through standard AWS credential chain
+- No cost data is sent to external services beyond AWS
+- VSCode may prompt for tool execution confirmation for security
+
+## Advanced Configuration
+
+### Environment Variables
+
+You can configure the MCP server using environment variables instead of VSCode inputs:
+
+```bash
+export AWS_REGION=us-east-1
+export AWS_ACCESS_KEY_ID=your-key-id
+export AWS_SECRET_ACCESS_KEY=your-secret-key
+```
+
+### Auto-Discovery
+
+VSCode can automatically discover MCP servers configured in other tools like Claude Desktop. Enable with:
+
+```json
+{
+  "chat.mcp.discovery.enabled": true
+}
+```
+
+## Support
+
+For issues with the MCP integration:
+1. Check the [ccExplorer GitHub issues](https://github.com/cduggn/ccExplorer/issues)
+2. Review VSCode MCP documentation
+3. Verify AWS permissions and configuration
+
+The MCP server provides comprehensive AWS cost analysis capabilities directly within your development environment, making it easy to understand and optimize cloud spending without leaving your IDE.

--- a/examples/copilot-chat-scenarios.md
+++ b/examples/copilot-chat-scenarios.md
@@ -1,0 +1,225 @@
+# GitHub Copilot Chat Scenarios with ccExplorer MCP
+
+This document provides practical examples of how to use ccExplorer's MCP server with GitHub Copilot Chat in VSCode for AI-powered AWS cost analysis.
+
+## Prerequisites
+
+- VSCode with MCP enabled (`"chat.mcp.enabled": true`)
+- ccExplorer MCP server configured (see [VSCode MCP Integration Guide](../docs/vscode-mcp-integration.md))
+- VSCode in Agent Mode with ccExplorer tools enabled
+
+## Basic Cost Analysis Scenarios
+
+### Monthly Cost Overview
+
+```
+@agent What were my total AWS costs for the last month grouped by service?
+```
+
+**Expected Result**: Copilot will use the `get_cost_and_usage` tool to retrieve costs from the previous month, automatically calculating the date range and grouping by AWS service.
+
+### Service-Specific Analysis
+
+```
+@agent Show me my EC2 costs for the last 3 months with monthly breakdown
+```
+
+**Expected Result**: Retrieves EC2-specific costs with monthly granularity, filtered to only include EC2 services.
+
+```
+@agent What are my S3 storage costs for the current quarter, excluding any discounts?
+```
+
+**Expected Result**: Filters for Amazon S3 services over the current quarter with discounts excluded.
+
+## Advanced Cost Analysis
+
+### Cost Optimization Scenarios
+
+```
+@agent Help me identify my top 5 most expensive AWS services this month and suggest optimization opportunities
+```
+
+**Expected Result**: Copilot retrieves current month costs grouped by service, analyzes the top 5, and provides optimization recommendations based on the cost patterns.
+
+### Cost Trend Analysis
+
+```
+@agent Compare my AWS costs between last month and this month. Which services had the biggest increase?
+```
+
+**Expected Result**: Copilot will make two separate API calls for different date ranges and compare the results to identify cost increases.
+
+```
+@agent Show me daily AWS costs for the last 7 days. Are there any unusual spikes?
+```
+
+**Expected Result**: Retrieves daily granularity data and analyzes for cost anomalies or spikes.
+
+## Tag-Based Cost Analysis
+
+### Project Cost Tracking
+
+```
+@agent What are the costs for my ProjectName tag "web-app" for the last month?
+```
+
+**Expected Result**: Groups costs by the ProjectName tag and filters for "web-app" value.
+
+```
+@agent Compare costs between my different projects (ProjectName tags) for the current month
+```
+
+**Expected Result**: Groups all costs by ProjectName tag to show project-by-project breakdown.
+
+### Environment Cost Analysis
+
+```
+@agent Show me production vs development environment costs for the last quarter
+```
+
+**Expected Result**: Assumes Environment tags exist and compares costs between production and development environments.
+
+## Operational Cost Scenarios
+
+### Budget Monitoring
+
+```
+@agent My AWS budget is $1000/month. How much have I spent so far this month and am I on track?
+```
+
+**Expected Result**: Copilot calculates month-to-date spending and projects end-of-month costs based on current usage patterns.
+
+### Cost Forecasting
+
+```
+@agent Based on my current AWS usage, what will my costs likely be next month?
+```
+
+**Expected Result**: While ccExplorer currently focuses on historical data, Copilot can analyze trends and provide projections.
+
+## Troubleshooting and Analysis
+
+### Unexpected Cost Investigation
+
+```
+@agent I notice my AWS bill increased significantly this month. Can you help me identify what's causing the increase?
+```
+
+**Expected Result**: Copilot compares current month to previous months, identifies services with the largest increases, and suggests investigation areas.
+
+```
+@agent Show me all costs over $100 for individual services in the last month
+```
+
+**Expected Result**: Retrieves and filters cost data to show only high-cost services.
+
+### Resource Utilization Analysis
+
+```
+@agent What are my data transfer costs for the last month? Break it down by operation type.
+```
+
+**Expected Result**: Filters for data transfer operations and groups by operation type to show bandwidth costs.
+
+```
+@agent Show me my storage costs across all AWS services for the last quarter
+```
+
+**Expected Result**: Identifies storage-related operations across multiple AWS services.
+
+## Complex Multi-Dimensional Analysis
+
+### Cross-Service Analysis
+
+```
+@agent Compare my compute costs (EC2, Lambda, ECS) vs storage costs (S3, EBS) for the last 3 months
+```
+
+**Expected Result**: Copilot categorizes services into compute and storage buckets and compares their costs over time.
+
+### Geographic Cost Analysis
+
+```
+@agent Show me costs by AWS region for the last month. Which regions are most expensive?
+```
+
+**Expected Result**: Groups costs by availability zone or region dimension to show geographic cost distribution.
+
+## Interactive Follow-Up Scenarios
+
+### Drill-Down Analysis
+
+**Initial Query:**
+```
+@agent What were my AWS costs last month grouped by service?
+```
+
+**Follow-up:**
+```
+@agent Can you break down the EC2 costs by operation type?
+```
+
+**Further Drill-down:**
+```
+@agent For the EC2 RunInstances operation, show me the daily breakdown
+```
+
+### Comparative Analysis
+
+**Initial Query:**
+```
+@agent Show me my current month AWS costs
+```
+
+**Follow-up:**
+```
+@agent How does this compare to the same month last year?
+```
+
+## Tips for Effective Queries
+
+### Specific Date Ranges
+- Use specific months: "January 2024", "last quarter", "past 6 months"
+- Be explicit about time periods: "from January 1 to March 31, 2024"
+
+### Clear Grouping Preferences
+- Specify how you want data grouped: "by service", "by tag", "by operation"
+- Ask for specific dimensions: "group by ProjectName tag and service"
+
+### Output Preferences
+- Request specific formats: "show as a table", "summarize the key findings"
+- Ask for explanations: "explain why these costs occurred"
+
+### Filter Specifications
+- Be specific about services: "only EC2 costs", "exclude data transfer charges"
+- Mention discount preferences: "including discounts", "excluding credits and refunds"
+
+## Error Handling and Troubleshooting
+
+If Copilot indicates it cannot access cost data:
+
+1. **Check MCP Server Status**:
+```
+@agent Can you check if the ccExplorer MCP server is running?
+```
+
+2. **Verify AWS Credentials**:
+```
+@agent Try to get costs for yesterday to test the connection
+```
+
+3. **Simplify the Query**:
+```
+@agent Just show me total AWS costs for last month
+```
+
+## Best Practices
+
+1. **Start Simple**: Begin with basic queries and add complexity
+2. **Be Specific**: Provide clear date ranges and grouping preferences
+3. **Use Follow-ups**: Build on previous queries for deeper analysis
+4. **Verify Results**: Cross-check important findings with AWS Console
+5. **Consider Context**: Remember that Copilot maintains conversation context for follow-up questions
+
+These scenarios demonstrate the power of combining ccExplorer's cost analysis capabilities with Copilot's natural language interface and analytical capabilities.

--- a/examples/vscode-user-settings.json
+++ b/examples/vscode-user-settings.json
@@ -1,0 +1,37 @@
+{
+  "// Enable MCP support in VSCode": "",
+  "chat.mcp.enabled": true,
+  
+  "// Global MCP server configuration for ccExplorer": "",
+  "// Replace /path/to/your/ccexplorer with the actual path to your binary": "",
+  "chat.mcp.servers": {
+    "ccExplorer": {
+      "type": "stdio",
+      "command": "/path/to/your/ccexplorer",
+      "args": ["mcp", "serve"],
+      "env": {
+        "AWS_REGION": "us-east-1"
+      }
+    }
+  },
+  
+  "// Optional: Enable auto-discovery of MCP servers from other tools like Claude Desktop": "",
+  "chat.mcp.discovery.enabled": true,
+  
+  "// Optional: Automatically confirm tool executions (use with caution)": "",
+  "// chat.agent.autoConfirm": true,
+  
+  "// Example with explicit AWS credentials (not recommended for production)": "",
+  "// \"chat.mcp.servers\": {": "",
+  "//   \"ccExplorer\": {": "",
+  "//     \"type\": \"stdio\",": "",
+  "//     \"command\": \"/path/to/your/ccexplorer\",": "",
+  "//     \"args\": [\"mcp\", \"serve\", \"--stdio\"],": "",
+  "//     \"env\": {": "",
+  "//       \"AWS_ACCESS_KEY_ID\": \"your-access-key\",": "",
+  "//       \"AWS_SECRET_ACCESS_KEY\": \"your-secret-key\",": "",
+  "//       \"AWS_REGION\": \"us-east-1\"": "",
+  "//     }": "",
+  "//   }": "",
+  "// }": ""
+}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be
 	github.com/go-echarts/go-echarts/v2 v2.4.1
 	github.com/jedib0t/go-pretty/v6 v6.5.8
+	github.com/mark3labs/mcp-go v0.32.0
 	github.com/sashabaranov/go-openai v1.30.3
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0
@@ -29,6 +30,7 @@ require (
 	github.com/aws/smithy-go v1.21.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
@@ -41,9 +43,11 @@ require (
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.11.0 // indirect
-	github.com/spf13/cast v1.6.0 // indirect
+	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
 	golang.org/x/sys v0.18.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/go-echarts/go-echarts/v2 v2.4.1 h1:imBFGngJ9zv/2zJVjK3k0uLL+LzyPDgzeV
 github.com/go-echarts/go-echarts/v2 v2.4.1/go.mod h1:56YlvzhW/a+du15f3S2qUGNDfKnFOeJSThBIrVFHDtI=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -56,6 +58,8 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
 github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
+github.com/mark3labs/mcp-go v0.32.0 h1:fgwmbfL2gbd67obg57OfV2Dnrhs1HtSdlY/i5fn7MU8=
+github.com/mark3labs/mcp-go v0.32.0/go.mod h1:rXqOudj/djTORU/ThxYx8fqEVj/5pvTuuebQ2RC7uk4=
 github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
 github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
@@ -81,8 +85,8 @@ github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9yS
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=
 github.com/spf13/afero v1.11.0/go.mod h1:GH9Y3pIexgf1MTIWtNGyogA5MwRIDXGUr+hbWNoBjkY=
-github.com/spf13/cast v1.6.0 h1:GEiTHELF+vaR5dhz3VqZfFSzZjYbgeKDpBxQVS4GYJ0=
-github.com/spf13/cast v1.6.0/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
+github.com/spf13/cast v1.7.1 h1:cuNEagBQEHWN1FnbGEjCXL2szYEXqfJPbP2HNUaca9Y=
+github.com/spf13/cast v1.7.1/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
 github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
 github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
@@ -92,6 +96,7 @@ github.com/spf13/viper v1.19.0/go.mod h1:GQUN9bilAbhU/jgc1bKs99f/suXKeUMct8Adx5+
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
@@ -100,6 +105,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 golang.org/x/exp v0.0.0-20230905200255-921286631fa9 h1:GoHiUyI/Tp2nVkLI2mCxVkOjsbSXD66ic0XW0js0R9g=

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -1,0 +1,146 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/cduggn/ccexplorer/internal/types"
+	"github.com/cduggn/ccexplorer/internal/utils"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// handleGetCostAndUsage handles the get_cost_and_usage MCP tool call
+func (s *Server) handleGetCostAndUsage(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	slog.Info("Handling get_cost_and_usage request", "arguments", request.Params.Arguments)
+
+	// Type assert the arguments
+	args, ok := request.Params.Arguments.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("invalid arguments type")
+	}
+
+	// Parse and validate arguments
+	mcpParams, err := s.parseGetCostAndUsageParams(args)
+	if err != nil {
+		return nil, fmt.Errorf("invalid parameters: %w", err)
+	}
+
+	// Translate MCP parameters to internal request type
+	internalRequest, err := s.translateMCPToInternalRequest(mcpParams)
+	if err != nil {
+		return nil, fmt.Errorf("failed to translate parameters: %w", err)
+	}
+
+	// Call AWS Cost Explorer service
+	result, err := s.awsService.GetCostAndUsage(ctx, internalRequest)
+	if err != nil {
+		return nil, fmt.Errorf("AWS service error: %w", err)
+	}
+
+	// Transform the response to a format suitable for MCP
+	response := utils.ToCostAndUsageOutputType(result, internalRequest)
+
+	// Convert to JSON for MCP response
+	responseJSON, err := json.MarshalIndent(response, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal response: %w", err)
+	}
+
+	// Return MCP tool result
+	return mcp.NewToolResultText(string(responseJSON)), nil
+}
+
+// parseGetCostAndUsageParams parses the MCP tool arguments into MCPToolParameters
+func (s *Server) parseGetCostAndUsageParams(args map[string]interface{}) (types.MCPToolParameters, error) {
+	var params types.MCPToolParameters
+
+	// Required parameters
+	if startDate, ok := args["start_date"].(string); ok {
+		params.StartDate = startDate
+	} else {
+		return params, fmt.Errorf("start_date is required and must be a string")
+	}
+
+	if endDate, ok := args["end_date"].(string); ok {
+		params.EndDate = endDate
+	} else {
+		return params, fmt.Errorf("end_date is required and must be a string")
+	}
+
+	// Optional parameters with defaults
+	if granularity, ok := args["granularity"].(string); ok {
+		params.Granularity = granularity
+	} else {
+		params.Granularity = "MONTHLY"
+	}
+
+	// Parse metrics - can be array or comma-separated string
+	if metricsInterface, ok := args["metrics"]; ok {
+		if metricsArray, ok := metricsInterface.([]interface{}); ok {
+			// Handle array format (typically from HTTP JSON-RPC)
+			for _, metric := range metricsArray {
+				if metricStr, ok := metric.(string); ok {
+					params.Metrics = append(params.Metrics, metricStr)
+				}
+			}
+		} else if metricsStr, ok := metricsInterface.(string); ok && metricsStr != "" {
+			// Handle string format (typically from stdio)
+			if strings.Contains(metricsStr, ",") {
+				// Comma-separated values
+				for _, metric := range strings.Split(metricsStr, ",") {
+					metric = strings.TrimSpace(metric)
+					if metric != "" {
+						params.Metrics = append(params.Metrics, metric)
+					}
+				}
+			} else {
+				// Single metric
+				params.Metrics = append(params.Metrics, metricsStr)
+			}
+		}
+	}
+	if len(params.Metrics) == 0 {
+		params.Metrics = []string{"UnblendedCost"}
+	}
+
+	// Parse group_by - can be array or comma-separated string
+	if groupByInterface, ok := args["group_by"]; ok {
+		if groupByArray, ok := groupByInterface.([]interface{}); ok {
+			// Handle array format (typically from HTTP JSON-RPC)
+			for _, groupBy := range groupByArray {
+				if groupByStr, ok := groupBy.(string); ok {
+					params.GroupBy = append(params.GroupBy, groupByStr)
+				}
+			}
+		} else if groupByStr, ok := groupByInterface.(string); ok && groupByStr != "" {
+			// Handle string format (typically from stdio)
+			if strings.Contains(groupByStr, ",") {
+				// Comma-separated values
+				for _, groupBy := range strings.Split(groupByStr, ",") {
+					groupBy = strings.TrimSpace(groupBy)
+					if groupBy != "" {
+						params.GroupBy = append(params.GroupBy, groupBy)
+					}
+				}
+			} else {
+				// Single group_by
+				params.GroupBy = append(params.GroupBy, groupByStr)
+			}
+		}
+	}
+
+	// Optional filter parameters
+	if filterService, ok := args["filter_by_service"].(string); ok && filterService != "" {
+		params.FilterByService = filterService
+	}
+
+	if excludeDiscounts, ok := args["exclude_discounts"].(bool); ok {
+		params.ExcludeDiscounts = excludeDiscounts
+	}
+
+	return params, nil
+}
+

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1,0 +1,59 @@
+package mcp
+
+import (
+	"log/slog"
+
+	"github.com/cduggn/ccexplorer/internal/ports"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// Server wraps the MCP server with ccExplorer-specific functionality
+type Server struct {
+	mcpServer  *server.MCPServer
+	awsService ports.AWSService
+}
+
+// NewServer creates a new MCP server instance for stdio transport
+func NewServer(awsService ports.AWSService) *Server {
+	slog.Info("Creating new ccExplorer MCP server")
+	
+	mcpServer := server.NewMCPServer(
+		"ccExplorer MCP Server",
+		"1.0.0",
+		server.WithToolCapabilities(true),
+	)
+
+	return &Server{
+		mcpServer:  mcpServer,
+		awsService: awsService,
+	}
+}
+
+// RegisterTools registers all available MCP tools with the server
+func (s *Server) RegisterTools() error {
+	slog.Info("Registering MCP tools")
+	
+	// Register the get_cost_and_usage tool
+	getCostTool := mcp.NewTool("get_cost_and_usage",
+		mcp.WithDescription("Query AWS Cost Explorer for cost and usage data"),
+		mcp.WithString("start_date", mcp.Required()),
+		mcp.WithString("end_date", mcp.Required()),
+		mcp.WithString("granularity", mcp.Enum("DAILY", "MONTHLY", "HOURLY")),
+		mcp.WithString("metrics"),
+		mcp.WithString("group_by"),
+		mcp.WithString("filter_by_service"),
+		mcp.WithBoolean("exclude_discounts"),
+	)
+
+	// Add tool to the MCP server with our handler
+	s.mcpServer.AddTool(getCostTool, s.handleGetCostAndUsage)
+	slog.Info("Successfully registered get_cost_and_usage tool")
+	
+	return nil
+}
+
+// MCPServer returns the underlying MCP server for stdio transport
+func (s *Server) MCPServer() *server.MCPServer {
+	return s.mcpServer
+}

--- a/internal/mcp/translator.go
+++ b/internal/mcp/translator.go
@@ -1,0 +1,128 @@
+package mcp
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cduggn/ccexplorer/internal/types"
+)
+
+// translateMCPToInternalRequest converts MCP parameters to internal CostAndUsageRequestType
+func (s *Server) translateMCPToInternalRequest(params types.MCPToolParameters) (types.CostAndUsageRequestType, error) {
+	var request types.CostAndUsageRequestType
+
+	// Basic time and granularity settings
+	request.Time = types.Time{
+		Start: params.StartDate,
+		End:   params.EndDate,
+	}
+	request.Granularity = params.Granularity
+	request.Metrics = params.Metrics
+	request.ExcludeDiscounts = params.ExcludeDiscounts
+
+	// Parse group_by parameters
+	var groupByDimension []string
+	var groupByTag []string
+
+	for _, groupBy := range params.GroupBy {
+		if strings.HasPrefix(groupBy, "TAG:") {
+			// Extract tag name from "TAG:TagName" format
+			tagName := strings.TrimPrefix(groupBy, "TAG:")
+			groupByTag = append(groupByTag, tagName)
+		} else {
+			// Regular dimension
+			groupByDimension = append(groupByDimension, groupBy)
+		}
+	}
+
+	request.GroupBy = groupByDimension
+	request.GroupByTag = groupByTag
+
+	// Handle filtering
+	if params.FilterByService != "" {
+		request.IsFilterByDimensionEnabled = true
+		request.DimensionFilter = map[string]string{
+			"SERVICE": params.FilterByService,
+		}
+	}
+
+	// Handle additional dimension filters
+	if len(params.FilterByDimension) > 0 {
+		request.IsFilterByDimensionEnabled = true
+		if request.DimensionFilter == nil {
+			request.DimensionFilter = make(map[string]string)
+		}
+		for key, value := range params.FilterByDimension {
+			request.DimensionFilter[key] = value
+		}
+	}
+
+	// Handle tag filters
+	if len(params.FilterByTag) > 0 {
+		request.IsFilterByTagEnabled = true
+		// For now, we'll handle the first tag filter
+		// This could be enhanced to support multiple tag filters
+		for key, value := range params.FilterByTag {
+			request.GroupByTag = append(request.GroupByTag, key)
+			request.TagFilterValue = value
+			break // Only handle first tag for now
+		}
+	}
+
+	// Set default print format for internal processing
+	request.PrintFormat = "json"
+
+	// Validate the request
+	if err := s.validateInternalRequest(request); err != nil {
+		return request, fmt.Errorf("invalid request: %w", err)
+	}
+
+	return request, nil
+}
+
+// validateInternalRequest validates the internal request structure
+func (s *Server) validateInternalRequest(request types.CostAndUsageRequestType) error {
+	// Validate required fields
+	if request.Time.Start == "" {
+		return fmt.Errorf("start date is required")
+	}
+	if request.Time.End == "" {
+		return fmt.Errorf("end date is required")
+	}
+
+	// Validate granularity
+	validGranularities := []string{"DAILY", "MONTHLY", "HOURLY"}
+	granularityValid := false
+	for _, valid := range validGranularities {
+		if request.Granularity == valid {
+			granularityValid = true
+			break
+		}
+	}
+	if !granularityValid {
+		return fmt.Errorf("invalid granularity: %s, must be one of %v", request.Granularity, validGranularities)
+	}
+
+	// Validate metrics
+	if len(request.Metrics) == 0 {
+		return fmt.Errorf("at least one metric is required")
+	}
+	validMetrics := []string{
+		"AmortizedCost", "BlendedCost", "NetAmortizedCost",
+		"NetUnblendedCost", "NormalizedUsageAmount", "UnblendedCost", "UsageQuantity",
+	}
+	for _, metric := range request.Metrics {
+		metricValid := false
+		for _, valid := range validMetrics {
+			if metric == valid {
+				metricValid = true
+				break
+			}
+		}
+		if !metricValid {
+			return fmt.Errorf("invalid metric: %s, must be one of %v", metric, validMetrics)
+		}
+	}
+
+	return nil
+}

--- a/internal/mcp/translator_test.go
+++ b/internal/mcp/translator_test.go
@@ -1,0 +1,256 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/cduggn/ccexplorer/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseGetCostAndUsageParams(t *testing.T) {
+	server := &Server{}
+
+	tests := []struct {
+		name     string
+		args     map[string]interface{}
+		expected types.MCPToolParameters
+		wantErr  bool
+	}{
+		{
+			name: "valid basic parameters",
+			args: map[string]interface{}{
+				"start_date": "2024-01-01",
+				"end_date":   "2024-01-31",
+			},
+			expected: types.MCPToolParameters{
+				StartDate:   "2024-01-01",
+				EndDate:     "2024-01-31",
+				Granularity: "MONTHLY",
+				Metrics:     []string{"UnblendedCost"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid parameters with all options",
+			args: map[string]interface{}{
+				"start_date":         "2024-01-01",
+				"end_date":           "2024-01-31",
+				"granularity":        "DAILY",
+				"metrics":            []interface{}{"AmortizedCost", "BlendedCost"},
+				"group_by":           []interface{}{"SERVICE", "TAG:Project"},
+				"filter_by_service":  "Amazon Simple Storage Service",
+				"exclude_discounts":  true,
+			},
+			expected: types.MCPToolParameters{
+				StartDate:         "2024-01-01",
+				EndDate:           "2024-01-31",
+				Granularity:       "DAILY",
+				Metrics:           []string{"AmortizedCost", "BlendedCost"},
+				GroupBy:           []string{"SERVICE", "TAG:Project"},
+				FilterByService:   "Amazon Simple Storage Service",
+				ExcludeDiscounts:  true,
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing start_date",
+			args: map[string]interface{}{
+				"end_date": "2024-01-31",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing end_date",
+			args: map[string]interface{}{
+				"start_date": "2024-01-01",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid start_date type",
+			args: map[string]interface{}{
+				"start_date": 123,
+				"end_date":   "2024-01-31",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := server.parseGetCostAndUsageParams(tt.args)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected.StartDate, result.StartDate)
+			assert.Equal(t, tt.expected.EndDate, result.EndDate)
+			assert.Equal(t, tt.expected.Granularity, result.Granularity)
+			assert.Equal(t, tt.expected.Metrics, result.Metrics)
+			assert.Equal(t, tt.expected.GroupBy, result.GroupBy)
+			assert.Equal(t, tt.expected.FilterByService, result.FilterByService)
+			assert.Equal(t, tt.expected.ExcludeDiscounts, result.ExcludeDiscounts)
+		})
+	}
+}
+
+func TestTranslateMCPToInternalRequest(t *testing.T) {
+	server := &Server{}
+
+	tests := []struct {
+		name     string
+		params   types.MCPToolParameters
+		wantErr  bool
+		validate func(t *testing.T, req types.CostAndUsageRequestType)
+	}{
+		{
+			name: "basic parameters",
+			params: types.MCPToolParameters{
+				StartDate:   "2024-01-01",
+				EndDate:     "2024-01-31",
+				Granularity: "MONTHLY",
+				Metrics:     []string{"UnblendedCost"},
+				GroupBy:     []string{"SERVICE"},
+			},
+			wantErr: false,
+			validate: func(t *testing.T, req types.CostAndUsageRequestType) {
+				assert.Equal(t, "2024-01-01", req.Time.Start)
+				assert.Equal(t, "2024-01-31", req.Time.End)
+				assert.Equal(t, "MONTHLY", req.Granularity)
+				assert.Equal(t, []string{"UnblendedCost"}, req.Metrics)
+				assert.Equal(t, []string{"SERVICE"}, req.GroupBy)
+				assert.False(t, req.IsFilterByDimensionEnabled)
+				assert.False(t, req.IsFilterByTagEnabled)
+			},
+		},
+		{
+			name: "with dimension and tag grouping",
+			params: types.MCPToolParameters{
+				StartDate:   "2024-01-01",
+				EndDate:     "2024-01-31",
+				Granularity: "DAILY",
+				Metrics:     []string{"AmortizedCost"},
+				GroupBy:     []string{"SERVICE", "TAG:Project"},
+			},
+			wantErr: false,
+			validate: func(t *testing.T, req types.CostAndUsageRequestType) {
+				assert.Equal(t, []string{"SERVICE"}, req.GroupBy)
+				assert.Equal(t, []string{"Project"}, req.GroupByTag)
+			},
+		},
+		{
+			name: "with service filter",
+			params: types.MCPToolParameters{
+				StartDate:       "2024-01-01",
+				EndDate:         "2024-01-31",
+				Granularity:     "MONTHLY",
+				Metrics:         []string{"UnblendedCost"},
+				FilterByService: "Amazon S3",
+			},
+			wantErr: false,
+			validate: func(t *testing.T, req types.CostAndUsageRequestType) {
+				assert.True(t, req.IsFilterByDimensionEnabled)
+				assert.Equal(t, "Amazon S3", req.DimensionFilter["SERVICE"])
+			},
+		},
+		{
+			name: "invalid granularity",
+			params: types.MCPToolParameters{
+				StartDate:   "2024-01-01",
+				EndDate:     "2024-01-31",
+				Granularity: "INVALID",
+				Metrics:     []string{"UnblendedCost"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid metric",
+			params: types.MCPToolParameters{
+				StartDate:   "2024-01-01",
+				EndDate:     "2024-01-31",
+				Granularity: "MONTHLY",
+				Metrics:     []string{"InvalidMetric"},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := server.translateMCPToInternalRequest(tt.params)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			if tt.validate != nil {
+				tt.validate(t, result)
+			}
+		})
+	}
+}
+
+func TestValidateInternalRequest(t *testing.T) {
+	server := &Server{}
+
+	tests := []struct {
+		name    string
+		request types.CostAndUsageRequestType
+		wantErr bool
+	}{
+		{
+			name: "valid request",
+			request: types.CostAndUsageRequestType{
+				Time:        types.Time{Start: "2024-01-01", End: "2024-01-31"},
+				Granularity: "MONTHLY",
+				Metrics:     []string{"UnblendedCost"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing start date",
+			request: types.CostAndUsageRequestType{
+				Time:        types.Time{End: "2024-01-31"},
+				Granularity: "MONTHLY",
+				Metrics:     []string{"UnblendedCost"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid granularity",
+			request: types.CostAndUsageRequestType{
+				Time:        types.Time{Start: "2024-01-01", End: "2024-01-31"},
+				Granularity: "YEARLY",
+				Metrics:     []string{"UnblendedCost"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "no metrics",
+			request: types.CostAndUsageRequestType{
+				Time:        types.Time{Start: "2024-01-01", End: "2024-01-31"},
+				Granularity: "MONTHLY",
+				Metrics:     []string{},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := server.validateInternalRequest(tt.request)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/types/mcp_types.go
+++ b/internal/types/mcp_types.go
@@ -1,0 +1,41 @@
+package types
+
+// MCPRequest represents the incoming MCP tool request
+type MCPRequest struct {
+	ToolName   string                 `json:"tool_name"`
+	Parameters MCPToolParameters      `json:"parameters"`
+}
+
+// MCPToolParameters represents the parameters for get_cost_and_usage tool
+type MCPToolParameters struct {
+	StartDate         string   `json:"start_date"`
+	EndDate           string   `json:"end_date"`
+	Granularity       string   `json:"granularity"`
+	Metrics           []string `json:"metrics"`
+	GroupBy           []string `json:"group_by"`
+	FilterByService   string   `json:"filter_by_service,omitempty"`
+	FilterByDimension map[string]string `json:"filter_by_dimension,omitempty"`
+	FilterByTag       map[string]string `json:"filter_by_tag,omitempty"`
+	ExcludeDiscounts  bool     `json:"exclude_discounts,omitempty"`
+}
+
+// MCPResponse represents the MCP tool response
+type MCPResponse struct {
+	Content []MCPContent `json:"content"`
+	IsError bool         `json:"isError,omitempty"`
+}
+
+// MCPContent represents the content within an MCP response
+type MCPContent struct {
+	Type string      `json:"type"`
+	Text string      `json:"text,omitempty"`
+	Data interface{} `json:"data,omitempty"`
+}
+
+// MCPError represents an MCP error response
+type MCPError struct {
+	Error   string `json:"error"`
+	Code    int    `json:"code,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+


### PR DESCRIPTION
- Add Model Context Protocol (MCP) server with stdio transport
- Implement get_cost_and_usage tool for AWS Cost Explorer queries
- Create VSCode workspace configuration (.vscode/mcp.json) for Copilot Chat
- Add comprehensive documentation and user examples
- Leverage mcp-go library for protocol compliance
- Support flexible parameter parsing (arrays and comma-separated strings)
- Include example configurations for global VSCode setup

The MCP server enables AI-powered AWS cost analysis through VSCode GitHub Copilot Chat, providing natural language querying of AWS Cost Explorer data.

🤖 Generated with [Claude Code](https://claude.ai/code)

### PR Checklist

- [ ] Read the [Contributing documentation](https://github.com/cduggn/ccExplorer/blob/main/CONTRIBUTING.md).
- [ ] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [ ] Describes the source of new concepts.
- [ ] References existing implementations as appropriate.
- [ ] Contains test coverage for new functions.
- [ ] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.