### PR TITLE
chore: update project to Go 1.25

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.22'
+        go-version: '1.25'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM  golang:1.22.0-alpine3.19 as build-stage
+FROM  golang:1.25-alpine as build-stage
 
 # Add Maintainer Info
 LABEL maintainer="Colin Duggan <duggan.colin@gmail.com>"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cduggn/ccexplorer
 
-go 1.24
+go 1.25
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.32.7
@@ -45,7 +45,6 @@ require (
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.uber.org/multierr v1.11.0 // indirect


### PR DESCRIPTION
## Summary

Update ccExplorer to use Go 1.25 as the minimum required version.

**BREAKING CHANGE:** Minimum Go version is now 1.25

## Changes

- Update `go.mod` to require Go 1.25
- Update `Dockerfile` build stage to `golang:1.25-alpine`
- Update `.github/workflows/codeql.yml` to use Go 1.25

## Notes

- CI workflows (`ci.yml`, `release.yml`) use `go-version-file: 'go.mod'` so they automatically pick up the new version
- All tests pass
- Build succeeds

Closes #405

## Test plan

- [x] `make test` passes
- [x] `make build` succeeds
- [ ] CI workflows pass on Go 1.25

🤖 Generated with [Claude Code](https://claude.com/claude-code)