### PR TITLE
chore: update project to Go 1.25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           cache: true
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: v2.8.0
           args: --timeout=5m

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,5 +48,5 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: latest
+          version: v2.8.0
           args: --timeout=5m

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.22'
+        go-version: '1.25'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM  golang:1.22.0-alpine3.19 as build-stage
+FROM  golang:1.25-alpine as build-stage
 
 # Add Maintainer Info
 LABEL maintainer="Colin Duggan <duggan.colin@gmail.com>"

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ $(GORELEASER):
 	go install github.com/goreleaser/goreleaser@latest
 
 $(GOLANGCI_LINT):
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.8.0
 
 .PHONY: setup
 setup:
@@ -24,7 +24,7 @@ test:
 
 .PHONY: lint
 lint: $(GOLANGCI_LINT)
-	$(GOLANGCI_LINT) run --color=always --sort-results ./...
+	$(GOLANGCI_LINT) run --color=always ./...
 
 .PHONY: lint-exp
 lint-exp: $(GOLANGCI_LINT)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cduggn/ccexplorer
 
-go 1.24
+go 1.25
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.32.7
@@ -45,7 +45,6 @@ require (
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -96,7 +96,6 @@ github.com/spf13/viper v1.19.0/go.mod h1:GQUN9bilAbhU/jgc1bKs99f/suXKeUMct8Adx5+
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
-github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=

--- a/internal/pinecone/pinecone.go
+++ b/internal/pinecone/pinecone.go
@@ -133,7 +133,7 @@ func (p *ClientAPI) sendRequest(req *http.Request, v any) error {
 		return fmt.Errorf("failed to send request: %w", err)
 	}
 
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 	if res.StatusCode < http.StatusOK || res.StatusCode >= http.
 		StatusBadRequest {
 		return fmt.Errorf("unexpected status code %d", res.StatusCode)

--- a/internal/writer/renderers.go
+++ b/internal/writer/renderers.go
@@ -200,7 +200,7 @@ func (r *CSVRenderer) Render(data *CSVOutput) error {
 	if err != nil {
 		return types.Error{Msg: "Error creating CSV file: " + err.Error()}
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	writer := csv.NewWriter(file)
 	defer writer.Flush()
@@ -234,7 +234,7 @@ func (r *ChartRenderer) Render(data *ChartOutput) error {
 	if err != nil {
 		return types.Error{Msg: "Failed creating chart HTML file: " + err.Error()}
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	if err := data.Page.Render(io.MultiWriter(file)); err != nil {
 		return err


### PR DESCRIPTION
## Summary
- Updates the project to Go 1.25
- Updates golangci-lint to v2.8.0 for Go 1.25 compatibility
- Fixes module path for golangci-lint v2 (`github.com/golangci/golangci-lint/v2`)
- Removes deprecated `--sort-results` flag from Makefile

## Test plan
- [x] `make lint` passes locally with golangci-lint v2.8.0
- [ ] CI build and test pass
- [ ] CI lint job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)